### PR TITLE
Bump reflectable support to ^0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file contains highlights of what changes on each version of the dson packag
 * Add include parameter to serialize function
 * Make exclude and depth parameter receive Symbols instead Strings (Not Sure about this)
 
+##Version 0.2.0
+* Breaking change: reflectable < 0.3.0 is not supported
+* Bump reflectable support to ^0.3.0
+
 ##Version 0.1.8+1
 * Extend version support for reflectable package
 

--- a/lib/src/annotations.dart
+++ b/lib/src/annotations.dart
@@ -43,6 +43,8 @@ class _Cyclical {
 /// This annotation specifies the object can be serialized
 class Serializable extends Reflectable {
   const Serializable() : super(
+      typeAnnotationQuantifyCapability,
+      superclassQuantifyCapability,
       invokingCapability,
       declarationsCapability,
       metadataCapability,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: dson
-version: 0.1.8+1
+version: 0.2.0
 author: Luis Vargas <luisvargastijerino@gmail.com>
 description: Convert Objects to Json and Json to Objects
 homepage: https://github.com/luisvt/dson
 environment:
   sdk: '>=1.8.0'
 dependencies:
-  drails_commons: '^0.0.5'
+  drails_commons: '>=0.0.6 <0.1.0'
 #    path: ../drails_commons
-  reflectable: '>=0.1.0 <0.3.0'
+  reflectable: '>=0.3.0 <0.4.0'
 #    path: ../reflectable/reflectable
 dev_dependencies:
   test: '>=0.12.0'


### PR DESCRIPTION
Breaking change: reflectable < 0.3.0 is not supported

All tests, including deserialization, are passed
