### PR TITLE
0.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: dart
 dart:
 #  - stable
   - dev
-script: pub run test
+script: dartanalyzer --fatal-warnings . && pub run build_runner test --delete-conflicting-outputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 * [ ] Add support for MessagePack
 * [ ] Add support for converting to array of values-only
 
+## 0.15.0
+   
+- upgrade `serializable_core` to version `0.11.0` since
+ this version now generates from methods which now allows
+ convert objects from generic values.
+- move `SerializedName` to `built_mirrors` library since
+ the serialized name is now generated at build time
+
 ## 0.14.0
 
 - upgrade `source_gen` to version `^0.9.0`

--- a/example/bin/exclude_attributes.g.dart
+++ b/example/bin/exclude_attributes.g.dart
@@ -35,7 +35,8 @@ abstract class _$StudentSerializable extends SerializableMap {
         name = __value;
         return;
       case 'courses':
-        courses = __value;
+        courses = fromSerialized(
+            __value, [() => new List<Course>(), () => new Course()]);
         return;
     }
     throwFieldNotFoundException(__key, 'Student');
@@ -70,10 +71,11 @@ abstract class _$CourseSerializable extends SerializableMap {
         id = __value;
         return;
       case 'beginDate':
-        beginDate = __value;
+        beginDate = fromSerializedDateTime(__value);
         return;
       case 'students':
-        students = __value;
+        students = fromSerialized(
+            __value, [() => new List<Student>(), () => new Student()]);
         return;
     }
     throwFieldNotFoundException(__key, 'Course');

--- a/example/bin/extend_serializables.g.dart
+++ b/example/bin/extend_serializables.g.dart
@@ -42,7 +42,7 @@ abstract class _$PersonSerializable extends SerializableMap {
         lastName = __value;
         return;
       case 'dateOfBirth':
-        dateOfBirth = __value;
+        dateOfBirth = fromSerializedDateTime(__value);
         return;
     }
     throwFieldNotFoundException(__key, 'Person');
@@ -94,7 +94,7 @@ abstract class _$EmployeeSerializable extends SerializableMap {
         lastName = __value;
         return;
       case 'dateOfBirth':
-        dateOfBirth = __value;
+        dateOfBirth = fromSerializedDateTime(__value);
         return;
     }
     throwFieldNotFoundException(__key, 'Employee');
@@ -138,7 +138,8 @@ abstract class _$ManagerSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'subordinates':
-        subordinates = __value;
+        subordinates = fromSerialized(
+            __value, [() => new List<Employee>(), () => new Employee()]);
         return;
       case 'salary':
         salary = __value;
@@ -153,7 +154,7 @@ abstract class _$ManagerSerializable extends SerializableMap {
         lastName = __value;
         return;
       case 'dateOfBirth':
-        dateOfBirth = __value;
+        dateOfBirth = fromSerializedDateTime(__value);
         return;
     }
     throwFieldNotFoundException(__key, 'Manager');

--- a/example/bin/json_to_object.g.dart
+++ b/example/bin/json_to_object.g.dart
@@ -26,7 +26,7 @@ abstract class _$EntityClassSerializable extends SerializableMap {
         return name;
       case '_setted':
         return _setted;
-      case 'otherName':
+      case 'renamed':
         return otherName;
       case 'notVisible':
         return notVisible;
@@ -46,14 +46,15 @@ abstract class _$EntityClassSerializable extends SerializableMap {
       case '_setted':
         _setted = __value;
         return;
-      case 'otherName':
+      case 'renamed':
         otherName = __value;
         return;
       case 'notVisible':
         notVisible = __value;
         return;
       case 'children':
-        children = __value;
+        children = fromSerialized(
+            __value, [() => new List<EntityClass>(), () => new EntityClass()]);
         return;
       case 'setted':
         setted = __value;
@@ -76,9 +77,9 @@ const $$EntityClass_fields_name =
 const $$EntityClass_fields__setted =
     const DeclarationMirror(name: '_setted', type: String);
 const $$EntityClass_fields_otherName = const DeclarationMirror(
-    name: 'otherName',
-    type: bool,
-    annotations: const [const SerializedName(r'renamed')]);
+  name: 'renamed',
+  type: bool,
+);
 const $$EntityClass_fields_notVisible = const DeclarationMirror(
     name: 'notVisible', type: String, annotations: const [ignore]);
 const $$EntityClass_fields_children =
@@ -92,21 +93,21 @@ const EntityClassClassMirror =
 }, fields: const {
   'name': $$EntityClass_fields_name,
   '_setted': $$EntityClass_fields__setted,
-  'otherName': $$EntityClass_fields_otherName,
+  'renamed': $$EntityClass_fields_otherName,
   'notVisible': $$EntityClass_fields_notVisible,
   'children': $$EntityClass_fields_children,
   'setted': $$EntityClass_fields_setted
 }, getters: const [
   'name',
   '_setted',
-  'otherName',
+  'renamed',
   'notVisible',
   'children',
   'setted'
 ], setters: const [
   'name',
   '_setted',
-  'otherName',
+  'renamed',
   'notVisible',
   'children',
   'setted'

--- a/example/bin/map_to_object.g.dart
+++ b/example/bin/map_to_object.g.dart
@@ -26,7 +26,7 @@ abstract class _$EntityClassSerializable extends SerializableMap {
         return name;
       case '_setted':
         return _setted;
-      case 'otherName':
+      case 'renamed':
         return otherName;
       case 'notVisible':
         return notVisible;
@@ -46,14 +46,15 @@ abstract class _$EntityClassSerializable extends SerializableMap {
       case '_setted':
         _setted = __value;
         return;
-      case 'otherName':
+      case 'renamed':
         otherName = __value;
         return;
       case 'notVisible':
         notVisible = __value;
         return;
       case 'children':
-        children = __value;
+        children = fromSerialized(
+            __value, [() => new List<EntityClass>(), () => new EntityClass()]);
         return;
       case 'setted':
         setted = __value;
@@ -76,9 +77,9 @@ const $$EntityClass_fields_name =
 const $$EntityClass_fields__setted =
     const DeclarationMirror(name: '_setted', type: String);
 const $$EntityClass_fields_otherName = const DeclarationMirror(
-    name: 'otherName',
-    type: bool,
-    annotations: const [const SerializedName(r'renamed')]);
+  name: 'renamed',
+  type: bool,
+);
 const $$EntityClass_fields_notVisible = const DeclarationMirror(
     name: 'notVisible', type: String, annotations: const [ignore]);
 const $$EntityClass_fields_children =
@@ -92,21 +93,21 @@ const EntityClassClassMirror =
 }, fields: const {
   'name': $$EntityClass_fields_name,
   '_setted': $$EntityClass_fields__setted,
-  'otherName': $$EntityClass_fields_otherName,
+  'renamed': $$EntityClass_fields_otherName,
   'notVisible': $$EntityClass_fields_notVisible,
   'children': $$EntityClass_fields_children,
   'setted': $$EntityClass_fields_setted
 }, getters: const [
   'name',
   '_setted',
-  'otherName',
+  'renamed',
   'notVisible',
   'children',
   'setted'
 ], setters: const [
   'name',
   '_setted',
-  'otherName',
+  'renamed',
   'notVisible',
   'children',
   'setted'

--- a/example/bin/object_to_json.g.dart
+++ b/example/bin/object_to_json.g.dart
@@ -37,7 +37,7 @@ abstract class _$PersonSerializable extends SerializableMap {
         return height;
       case 'dateOfBirth':
         return dateOfBirth;
-      case 'otherName':
+      case 'renamed':
         return otherName;
       case 'notVisible':
         return notVisible;
@@ -64,9 +64,9 @@ abstract class _$PersonSerializable extends SerializableMap {
         height = __value;
         return;
       case 'dateOfBirth':
-        dateOfBirth = __value;
+        dateOfBirth = fromSerializedDateTime(__value);
         return;
-      case 'otherName':
+      case 'renamed':
         otherName = __value;
         return;
       case 'notVisible':
@@ -98,9 +98,9 @@ const $$Person_fields_height =
 const $$Person_fields_dateOfBirth =
     const DeclarationMirror(name: 'dateOfBirth', type: DateTime);
 const $$Person_fields_otherName = const DeclarationMirror(
-    name: 'otherName',
-    type: String,
-    annotations: const [const SerializedName(r'renamed')]);
+  name: 'renamed',
+  type: String,
+);
 const $$Person_fields_notVisible = const DeclarationMirror(
     name: 'notVisible', type: String, annotations: const [ignore]);
 const $$Person_fields__private =
@@ -117,7 +117,7 @@ const PersonClassMirror =
   'lastName': $$Person_fields_lastName,
   'height': $$Person_fields_height,
   'dateOfBirth': $$Person_fields_dateOfBirth,
-  'otherName': $$Person_fields_otherName,
+  'renamed': $$Person_fields_otherName,
   'notVisible': $$Person_fields_notVisible,
   '_private': $$Person_fields__private,
   'doGetter': $$Person_fields_doGetter
@@ -127,7 +127,7 @@ const PersonClassMirror =
   'lastName',
   'height',
   'dateOfBirth',
-  'otherName',
+  'renamed',
   'notVisible',
   '_private',
   'doGetter'
@@ -137,7 +137,7 @@ const PersonClassMirror =
   'lastName',
   'height',
   'dateOfBirth',
-  'otherName',
+  'renamed',
   'notVisible',
   '_private'
 ]);

--- a/example/bin/object_to_map.g.dart
+++ b/example/bin/object_to_map.g.dart
@@ -37,7 +37,7 @@ abstract class _$PersonSerializable extends SerializableMap {
         return height;
       case 'dateOfBirth':
         return dateOfBirth;
-      case 'otherName':
+      case 'renamed':
         return otherName;
       case 'notVisible':
         return notVisible;
@@ -64,9 +64,9 @@ abstract class _$PersonSerializable extends SerializableMap {
         height = __value;
         return;
       case 'dateOfBirth':
-        dateOfBirth = __value;
+        dateOfBirth = fromSerializedDateTime(__value);
         return;
-      case 'otherName':
+      case 'renamed':
         otherName = __value;
         return;
       case 'notVisible':
@@ -98,9 +98,9 @@ const $$Person_fields_height =
 const $$Person_fields_dateOfBirth =
     const DeclarationMirror(name: 'dateOfBirth', type: DateTime);
 const $$Person_fields_otherName = const DeclarationMirror(
-    name: 'otherName',
-    type: String,
-    annotations: const [const SerializedName(r'renamed')]);
+  name: 'renamed',
+  type: String,
+);
 const $$Person_fields_notVisible = const DeclarationMirror(
     name: 'notVisible', type: String, annotations: const [ignore]);
 const $$Person_fields__private =
@@ -117,7 +117,7 @@ const PersonClassMirror =
   'lastName': $$Person_fields_lastName,
   'height': $$Person_fields_height,
   'dateOfBirth': $$Person_fields_dateOfBirth,
-  'otherName': $$Person_fields_otherName,
+  'renamed': $$Person_fields_otherName,
   'notVisible': $$Person_fields_notVisible,
   '_private': $$Person_fields__private,
   'doGetter': $$Person_fields_doGetter
@@ -127,7 +127,7 @@ const PersonClassMirror =
   'lastName',
   'height',
   'dateOfBirth',
-  'otherName',
+  'renamed',
   'notVisible',
   '_private',
   'doGetter'
@@ -137,7 +137,7 @@ const PersonClassMirror =
   'lastName',
   'height',
   'dateOfBirth',
-  'otherName',
+  'renamed',
   'notVisible',
   '_private'
 ]);

--- a/example/bin/serialize_cyclical.g.dart
+++ b/example/bin/serialize_cyclical.g.dart
@@ -46,10 +46,10 @@ abstract class _$EmployeeSerializable extends SerializableMap {
         lastName = __value;
         return;
       case 'address':
-        address = __value;
+        address = fromSerialized(__value, () => new Address());
         return;
       case 'manager':
-        manager = __value;
+        manager = fromSerialized(__value, () => new Employee());
         return;
     }
     throwFieldNotFoundException(__key, 'Employee');
@@ -108,7 +108,7 @@ abstract class _$AddressSerializable extends SerializableMap {
         postalCode = __value;
         return;
       case 'owner':
-        owner = __value;
+        owner = fromSerialized(__value, () => new Employee());
         return;
     }
     throwFieldNotFoundException(__key, 'Address');

--- a/example/bin/serialize_cyclical_list.g.dart
+++ b/example/bin/serialize_cyclical_list.g.dart
@@ -35,7 +35,8 @@ abstract class _$StudentSerializable extends SerializableMap {
         name = __value;
         return;
       case 'courses':
-        courses = __value;
+        courses = fromSerialized(
+            __value, [() => new List<Course>(), () => new Course()]);
         return;
     }
     throwFieldNotFoundException(__key, 'Student');
@@ -70,10 +71,11 @@ abstract class _$CourseSerializable extends SerializableMap {
         id = __value;
         return;
       case 'beginDate':
-        beginDate = __value;
+        beginDate = fromSerializedDateTime(__value);
         return;
       case 'students':
-        students = __value;
+        students = fromSerialized(
+            __value, [() => new List<Student>(), () => new Student()]);
         return;
     }
     throwFieldNotFoundException(__key, 'Course');

--- a/example/bin/serialize_generic.g.dart
+++ b/example/bin/serialize_generic.g.dart
@@ -28,7 +28,7 @@ abstract class _$SomeObjectSerializable<T> extends SerializableMap {
         id = __value;
         return;
       case 'genericList':
-        genericList = __value;
+        genericList = fromSerialized(__value, () => new List<T>());
         return;
     }
     throwFieldNotFoundException(__key, 'SomeObject');

--- a/example/web/main.g.dart
+++ b/example/web/main.g.dart
@@ -42,7 +42,7 @@ abstract class _$PersonSerializable extends SerializableMap {
         lastName = __value;
         return;
       case 'dateOfBirth':
-        dateOfBirth = __value;
+        dateOfBirth = fromSerializedDateTime(__value);
         return;
     }
     throwFieldNotFoundException(__key, 'Person');
@@ -94,7 +94,7 @@ abstract class _$EmployeeSerializable extends SerializableMap {
         lastName = __value;
         return;
       case 'dateOfBirth':
-        dateOfBirth = __value;
+        dateOfBirth = fromSerializedDateTime(__value);
         return;
     }
     throwFieldNotFoundException(__key, 'Employee');
@@ -138,7 +138,8 @@ abstract class _$ManagerSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'subordinates':
-        subordinates = __value;
+        subordinates = fromSerialized(
+            __value, [() => new List<Employee>(), () => new Employee()]);
         return;
       case 'salary':
         salary = __value;
@@ -153,7 +154,7 @@ abstract class _$ManagerSerializable extends SerializableMap {
         lastName = __value;
         return;
       case 'dateOfBirth':
-        dateOfBirth = __value;
+        dateOfBirth = fromSerializedDateTime(__value);
         return;
     }
     throwFieldNotFoundException(__key, 'Manager');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dson
-version: 0.14.0
+version: 0.15.0
 author: Luis Vargas <luisvargastijerino@gmail.com>
 description: Convert Objects to Json and Json to Objects
 homepage: https://github.com/luisvt/dson
@@ -10,11 +10,11 @@ dependencies:
   build: ^0.12.0
   analyzer: ^0.32.0
   logging: ^0.11.0
-  dson_core: ^0.14.0
+  dson_core: ^0.15.0
 #  dson_core:
 #    path: ../dson_core
-  built_mirrors_core: ^0.9.0
-  serializable_core: ^0.10.0
+#  built_mirrors_core: ^0.9.0
+#  serializable_core: ^0.10.0
 #dependency_overrides:
 #  built_mirrors:
 #    path: ../built_mirrors

--- a/test/deserializer/deserialize_enums_test.g.dart
+++ b/test/deserializer/deserialize_enums_test.g.dart
@@ -21,7 +21,7 @@ abstract class _$ObjectWithEnumSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'color':
-        color = __value;
+        color = fromSerializedEnum(__value, Color, () => Color.values);
         return;
     }
     throwFieldNotFoundException(__key, 'ObjectWithEnum');

--- a/test/deserializer/deserialize_inmutable_class_test.dart
+++ b/test/deserializer/deserialize_inmutable_class_test.dart
@@ -30,6 +30,11 @@ class ImmutableClassInvalidParameter extends _$ImmutableClassInvalidParameterSer
   const ImmutableClassInvalidParameter(String aName) : name = aName;
 }
 
+@serializable
+class ListWithImmutableClass {
+  List<ImmutableClass> immutables;
+}
+
 main() {
   _initMirrors();
 

--- a/test/deserializer/deserialize_inmutable_class_test.g.dart
+++ b/test/deserializer/deserialize_inmutable_class_test.g.dart
@@ -14,7 +14,7 @@ abstract class _$ImmutableClassSerializable extends SerializableMap {
     switch (__key) {
       case 'name':
         return name;
-      case 'renamed':
+      case 'the_renamed':
         return renamed;
     }
     throwFieldNotFoundException(__key, 'ImmutableClass');
@@ -77,6 +77,33 @@ abstract class _$ImmutableClassInvalidParameterSerializable
       ImmutableClassInvalidParameterClassMirror.fields.keys;
 }
 
+abstract class _$ListWithImmutableClassSerializable extends SerializableMap {
+  List<ImmutableClass> get immutables;
+  void set immutables(List<ImmutableClass> v);
+
+  operator [](Object __key) {
+    switch (__key) {
+      case 'immutables':
+        return immutables;
+    }
+    throwFieldNotFoundException(__key, 'ListWithImmutableClass');
+  }
+
+  operator []=(Object __key, __value) {
+    switch (__key) {
+      case 'immutables':
+        immutables = fromSerialized(__value, [
+          () => new List<ImmutableClass>(),
+          () => new ImmutableClass(__value['name'], __value['the_renamed'])
+        ]);
+        return;
+    }
+    throwFieldNotFoundException(__key, 'ListWithImmutableClass');
+  }
+
+  Iterable<String> get keys => ListWithImmutableClassClassMirror.fields.keys;
+}
+
 // **************************************************************************
 // MirrorsGenerator
 // **************************************************************************
@@ -87,10 +114,10 @@ _ImmutableClass__Constructor([positionalParams, namedParams]) =>
 const $$ImmutableClass_fields_name =
     const DeclarationMirror(name: 'name', type: String, isFinal: true);
 const $$ImmutableClass_fields_renamed = const DeclarationMirror(
-    name: 'renamed',
-    type: String,
-    isFinal: true,
-    annotations: const [const SerializedName(r'the_renamed')]);
+  name: 'the_renamed',
+  type: String,
+  isFinal: true,
+);
 
 const ImmutableClassClassMirror =
     const ClassMirror(name: 'ImmutableClass', constructors: const {
@@ -98,15 +125,16 @@ const ImmutableClassClassMirror =
       name: '',
       positionalParameters: const [
         const DeclarationMirror(name: 'name', type: String, isRequired: true),
-        const DeclarationMirror(name: 'renamed', type: String, isRequired: true)
+        const DeclarationMirror(
+            name: 'the_renamed', type: String, isRequired: true)
       ],
       $call: _ImmutableClass__Constructor)
 }, fields: const {
   'name': $$ImmutableClass_fields_name,
-  'renamed': $$ImmutableClass_fields_renamed
+  'the_renamed': $$ImmutableClass_fields_renamed
 }, getters: const [
   'name',
-  'renamed'
+  'the_renamed'
 ]);
 
 _ImmutableWithOptionalParameters__Constructor(
@@ -164,6 +192,28 @@ const ImmutableClassInvalidParameterClassMirror = const ClassMirror(
       'name'
     ]);
 
+_ListWithImmutableClass__Constructor([positionalParams, namedParams]) =>
+    new ListWithImmutableClass();
+
+const $$ListWithImmutableClass_fields_immutables = const DeclarationMirror(
+    name: 'immutables', type: const [List, ImmutableClass]);
+
+const ListWithImmutableClassClassMirror = const ClassMirror(
+    name: 'ListWithImmutableClass',
+    constructors: const {
+      '': const FunctionMirror(
+          name: '', $call: _ListWithImmutableClass__Constructor)
+    },
+    fields: const {
+      'immutables': $$ListWithImmutableClass_fields_immutables
+    },
+    getters: const [
+      'immutables'
+    ],
+    setters: const [
+      'immutables'
+    ]);
+
 // **************************************************************************
 // InitMirrorsGenerator
 // **************************************************************************
@@ -172,6 +222,7 @@ _initMirrors() {
   initClassMirrors({
     ImmutableClass: ImmutableClassClassMirror,
     ImmutableWithOptionalParameters: ImmutableWithOptionalParametersClassMirror,
-    ImmutableClassInvalidParameter: ImmutableClassInvalidParameterClassMirror
+    ImmutableClassInvalidParameter: ImmutableClassInvalidParameterClassMirror,
+    ListWithImmutableClass: ListWithImmutableClassClassMirror
   });
 }

--- a/test/deserializer/deserializer_generic_test.g.dart
+++ b/test/deserializer/deserializer_generic_test.g.dart
@@ -48,7 +48,8 @@ abstract class _$ListClassSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'list':
-        list = __value;
+        list = fromSerialized(
+            __value, [() => new List<SimpleClass>(), () => new SimpleClass()]);
         return;
     }
     throwFieldNotFoundException(__key, 'ListClass');
@@ -72,7 +73,7 @@ abstract class _$ListTClassSerializable<T> extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'listT':
-        listT = __value;
+        listT = fromSerialized(__value, () => new List<T>());
         return;
     }
     throwFieldNotFoundException(__key, 'ListTClass');
@@ -96,7 +97,10 @@ abstract class _$ListListClassSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'list':
-        list = __value;
+        list = fromSerialized(__value, [
+          () => new List<List<SimpleClass>>(),
+          [() => new List<SimpleClass>(), () => new SimpleClass()]
+        ]);
         return;
     }
     throwFieldNotFoundException(__key, 'ListListClass');
@@ -120,7 +124,13 @@ abstract class _$ListListListClassSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'list':
-        list = __value;
+        list = fromSerialized(__value, [
+          () => new List<List<List<SimpleClass>>>(),
+          [
+            () => new List<List<SimpleClass>>(),
+            [() => new List<SimpleClass>(), () => new SimpleClass()]
+          ]
+        ]);
         return;
     }
     throwFieldNotFoundException(__key, 'ListListListClass');
@@ -144,7 +154,10 @@ abstract class _$ListMapClassSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'list':
-        list = __value;
+        list = fromSerialized(__value, [
+          () => new List<Map<String, SimpleClass>>(),
+          [() => new Map<String, SimpleClass>(), null, () => new SimpleClass()]
+        ]);
         return;
     }
     throwFieldNotFoundException(__key, 'ListMapClass');
@@ -168,7 +181,17 @@ abstract class _$ListListMapClassSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'list':
-        list = __value;
+        list = fromSerialized(__value, [
+          () => new List<List<Map<String, SimpleClass>>>(),
+          [
+            () => new List<Map<String, SimpleClass>>(),
+            [
+              () => new Map<String, SimpleClass>(),
+              null,
+              () => new SimpleClass()
+            ]
+          ]
+        ]);
         return;
     }
     throwFieldNotFoundException(__key, 'ListListMapClass');
@@ -192,7 +215,11 @@ abstract class _$MapClassSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'myMap':
-        myMap = __value;
+        myMap = fromSerialized(__value, [
+          () => new Map<String, SimpleClass>(),
+          null,
+          () => new SimpleClass()
+        ]);
         return;
     }
     throwFieldNotFoundException(__key, 'MapClass');

--- a/test/deserializer/deserializer_test.dart
+++ b/test/deserializer/deserializer_test.dart
@@ -58,6 +58,7 @@ class TestSetter extends _$TestSetterSerializable {
   String _name;
 
   String get name => _name;
+
   set name(String n) => _name = n;
 }
 
@@ -89,7 +90,7 @@ class SimpleMap extends _$SimpleMapSerializable {
 
 @serializable
 class SimpleMapString extends _$SimpleMapStringSerializable {
-  Map<String,num> myMap;
+  Map<String, num> myMap;
 }
 
 @serializable
@@ -101,7 +102,10 @@ main() {
   _initMirrors();
 
   test('deserialize: simple.', () {
-    TestClass1 test = fromJson('{"name":"test","matter":true,"intNumber":2, "intNumber2":2.0, "doubleNumber": 2, "doubleNumber2": 2.0, "number":5,"list":[1,2,3],"myMap":{"k":"o"},"the_renamed":"test"}', TestClass1);
+    TestClass1 test = fromJson(
+        '{"name":"test","matter":true,"intNumber":2, "intNumber2":2, "doubleNumber": 2.0, "doubleNumber2": 2.0,'
+        ' "number":5,"list":[1,2,3],"myMap":{"k":"o"},"the_renamed":"test"}',
+        TestClass1);
     expect(test.name, 'test');
     expect(test.matter, true);
     expect(test.intNumber, 2);
@@ -120,7 +124,7 @@ main() {
     try {
       NestedClass test = fromJson('{"name":"failure"}', NestedClass);
       expect(test.name, equals("failure"));
-    } catch(ex) {
+    } catch (ex) {
       err = ex;
     }
 
@@ -158,7 +162,7 @@ main() {
   });
 
   test('deserialize: list of simple class', () {
-    List<SimpleClass> test = fromJson('[{"name":"test"},{"name":"test2"}]', const [List, SimpleClass]);
+    List<SimpleClass> test = fromJson('[{"name":"test"},{"name":"test2"}]', [() => List<SimpleClass>(), SimpleClass]);
     expect(test[0].name, "test");
     expect(test[1].name, "test2");
   });
@@ -168,10 +172,11 @@ main() {
     expect(test.names.contains("test"), true);
   });
 
-
   test('deserialize: map of simple class', () {
-    Map<String, SimpleClass> test = fromJson('{"key1":{"name":"test"},"key2":{"name":"test2"}}',
-        const [Map, const [String, SimpleClass]]);
+    Map<String, SimpleClass> test = fromJson('{"key1":{"name":"test"},"key2":{"name":"test2"}}', [
+      () => Map<String, SimpleClass>(),
+      const [String, SimpleClass]
+    ]);
     expect(test["key1"].name, "test");
     expect(test["key2"].name, "test2");
   });
@@ -191,7 +196,9 @@ main() {
   });
 
   test('mapListToObjectList: List of SimplemapString', () {
-    List<SimpleMapString> test = fromMap([{"myMap": {"test": 1, "test2": 2}}, {"myMap": {"test": 3, "test2": 4}}], [List, SimpleMapString]);
+    List<SimpleMapString> test = fromMap(
+        [{"myMap": {"test": 1, "test2": 2}}, {"myMap": {"test": 3, "test2": 4}}],
+        [() => List<SimpleMapString>(), SimpleMapString]);
     expect(test[0].myMap["test"], 1);
     expect(test[0].myMap["test2"], 2);
     expect(test[1].myMap["test"], 3);

--- a/test/deserializer/deserializer_test.g.dart
+++ b/test/deserializer/deserializer_test.g.dart
@@ -21,7 +21,7 @@ abstract class _$SimpleDateContainerSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'testDate':
-        testDate = __value;
+        testDate = fromSerializedDateTime(__value);
         return;
     }
     throwFieldNotFoundException(__key, 'SimpleDateContainer');
@@ -80,7 +80,7 @@ abstract class _$TestClass1Serializable extends SerializableMap {
         return doubleNumber2;
       case 'ignored':
         return ignored;
-      case 'renamed':
+      case 'the_renamed':
         return renamed;
     }
     throwFieldNotFoundException(__key, 'TestClass1');
@@ -98,13 +98,13 @@ abstract class _$TestClass1Serializable extends SerializableMap {
         number = __value;
         return;
       case 'list':
-        list = __value;
+        list = fromSerialized(__value, () => new List<dynamic>());
         return;
       case 'myMap':
-        myMap = __value;
+        myMap = fromSerialized(__value, () => new Map<dynamic, dynamic>());
         return;
       case 'child':
-        child = __value;
+        child = fromSerialized(__value, () => new TestClass1());
         return;
       case 'intNumber':
         intNumber = __value;
@@ -121,7 +121,7 @@ abstract class _$TestClass1Serializable extends SerializableMap {
       case 'ignored':
         ignored = __value;
         return;
-      case 'renamed':
+      case 'the_renamed':
         renamed = __value;
         return;
     }
@@ -170,7 +170,7 @@ abstract class _$SetClassSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'names':
-        names = __value;
+        names = fromSerialized(__value, () => new Set<String>());
         return;
     }
     throwFieldNotFoundException(__key, 'SetClass');
@@ -263,10 +263,10 @@ abstract class _$NestedClassSerializable extends SerializableMap {
         name = __value;
         return;
       case 'list':
-        list = __value;
+        list = fromSerialized(__value, () => new List<dynamic>());
         return;
       case 'getter':
-        getter = __value;
+        getter = fromSerialized(__value, () => new TestGetter());
         return;
     }
     throwFieldNotFoundException(__key, 'NestedClass');
@@ -317,7 +317,7 @@ abstract class _$SimpleListSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'list':
-        list = __value;
+        list = fromSerialized(__value, () => new List<dynamic>());
         return;
     }
     throwFieldNotFoundException(__key, 'SimpleList');
@@ -341,7 +341,7 @@ abstract class _$SimpleMapSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'myMap':
-        myMap = __value;
+        myMap = fromSerialized(__value, () => new Map<dynamic, dynamic>());
         return;
     }
     throwFieldNotFoundException(__key, 'SimpleMap');
@@ -365,7 +365,7 @@ abstract class _$SimpleMapStringSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'myMap':
-        myMap = __value;
+        myMap = fromSerialized(__value, () => new Map<String, num>());
         return;
     }
     throwFieldNotFoundException(__key, 'SimpleMapString');
@@ -447,9 +447,9 @@ const $$TestClass1_fields_doubleNumber2 =
 const $$TestClass1_fields_ignored = const DeclarationMirror(
     name: 'ignored', type: bool, annotations: const [ignore]);
 const $$TestClass1_fields_renamed = const DeclarationMirror(
-    name: 'renamed',
-    type: String,
-    annotations: const [const SerializedName(r'the_renamed')]);
+  name: 'the_renamed',
+  type: String,
+);
 
 const TestClass1ClassMirror =
     const ClassMirror(name: 'TestClass1', constructors: const {
@@ -466,7 +466,7 @@ const TestClass1ClassMirror =
   'doubleNumber': $$TestClass1_fields_doubleNumber,
   'doubleNumber2': $$TestClass1_fields_doubleNumber2,
   'ignored': $$TestClass1_fields_ignored,
-  'renamed': $$TestClass1_fields_renamed
+  'the_renamed': $$TestClass1_fields_renamed
 }, getters: const [
   'name',
   'matter',
@@ -479,7 +479,7 @@ const TestClass1ClassMirror =
   'doubleNumber',
   'doubleNumber2',
   'ignored',
-  'renamed'
+  'the_renamed'
 ], setters: const [
   'name',
   'matter',
@@ -492,7 +492,7 @@ const TestClass1ClassMirror =
   'doubleNumber',
   'doubleNumber2',
   'ignored',
-  'renamed'
+  'the_renamed'
 ]);
 
 _JustObject__Constructor([positionalParams, namedParams]) => new JustObject();

--- a/test/serializer/cyclic_reference_test.g.dart
+++ b/test/serializer/cyclic_reference_test.g.dart
@@ -46,10 +46,10 @@ abstract class _$EmployeeSerializable extends SerializableMap {
         lastName = __value;
         return;
       case 'address':
-        address = __value;
+        address = fromSerialized(__value, () => new Address());
         return;
       case 'manager':
-        manager = __value;
+        manager = fromSerialized(__value, () => new Employee());
         return;
     }
     throwFieldNotFoundException(__key, 'Employee');
@@ -108,7 +108,7 @@ abstract class _$AddressSerializable extends SerializableMap {
         postalCode = __value;
         return;
       case 'owner':
-        owner = __value;
+        owner = fromSerialized(__value, () => new Employee());
         return;
     }
     throwFieldNotFoundException(__key, 'Address');
@@ -150,10 +150,10 @@ abstract class _$Employee2Serializable extends SerializableMap {
         lastName = __value;
         return;
       case 'address':
-        address = __value;
+        address = fromSerialized(__value, () => new Address2());
         return;
       case 'manager':
-        manager = __value;
+        manager = fromSerialized(__value, () => new Employee2());
         return;
     }
     throwFieldNotFoundException(__key, 'Employee2');
@@ -205,7 +205,7 @@ abstract class _$Address2Serializable extends SerializableMap {
         postalCode = __value;
         return;
       case 'owner':
-        owner = __value;
+        owner = fromSerialized(__value, () => new Employee2());
         return;
     }
     throwFieldNotFoundException(__key, 'Address2');
@@ -243,7 +243,8 @@ abstract class _$StudentSerializable extends SerializableMap {
         name = __value;
         return;
       case 'courses':
-        courses = __value;
+        courses = fromSerialized(
+            __value, [() => new List<Course>(), () => new Course()]);
         return;
     }
     throwFieldNotFoundException(__key, 'Student');
@@ -278,10 +279,11 @@ abstract class _$CourseSerializable extends SerializableMap {
         id = __value;
         return;
       case 'beginDate':
-        beginDate = __value;
+        beginDate = fromSerializedDateTime(__value);
         return;
       case 'students':
-        students = __value;
+        students = fromSerialized(
+            __value, [() => new List<Student>(), () => new Student()]);
         return;
     }
     throwFieldNotFoundException(__key, 'Course');

--- a/test/serializer/exclude_test.g.dart
+++ b/test/serializer/exclude_test.g.dart
@@ -46,10 +46,10 @@ abstract class _$EmployeeSerializable extends SerializableMap {
         lastName = __value;
         return;
       case 'address':
-        address = __value;
+        address = fromSerialized(__value, () => new Address());
         return;
       case 'manager':
-        manager = __value;
+        manager = fromSerialized(__value, () => new Employee());
         return;
     }
     throwFieldNotFoundException(__key, 'Employee');
@@ -108,7 +108,7 @@ abstract class _$AddressSerializable extends SerializableMap {
         postalCode = __value;
         return;
       case 'owner':
-        owner = __value;
+        owner = fromSerialized(__value, () => new Employee());
         return;
     }
     throwFieldNotFoundException(__key, 'Address');
@@ -150,10 +150,10 @@ abstract class _$Employee2Serializable extends SerializableMap {
         lastName = __value;
         return;
       case 'address':
-        address = __value;
+        address = fromSerialized(__value, () => new Address2());
         return;
       case 'manager':
-        manager = __value;
+        manager = fromSerialized(__value, () => new Employee2());
         return;
     }
     throwFieldNotFoundException(__key, 'Employee2');
@@ -205,7 +205,7 @@ abstract class _$Address2Serializable extends SerializableMap {
         postalCode = __value;
         return;
       case 'owner':
-        owner = __value;
+        owner = fromSerialized(__value, () => new Employee2());
         return;
     }
     throwFieldNotFoundException(__key, 'Address2');
@@ -243,7 +243,8 @@ abstract class _$StudentSerializable extends SerializableMap {
         name = __value;
         return;
       case 'courses':
-        courses = __value;
+        courses = fromSerialized(
+            __value, [() => new List<Course>(), () => new Course()]);
         return;
     }
     throwFieldNotFoundException(__key, 'Student');
@@ -278,10 +279,11 @@ abstract class _$CourseSerializable extends SerializableMap {
         id = __value;
         return;
       case 'beginDate':
-        beginDate = __value;
+        beginDate = fromSerializedDateTime(__value);
         return;
       case 'students':
-        students = __value;
+        students = fromSerialized(
+            __value, [() => new List<Student>(), () => new Student()]);
         return;
     }
     throwFieldNotFoundException(__key, 'Course');

--- a/test/serializer/serialize_enums_test.g.dart
+++ b/test/serializer/serialize_enums_test.g.dart
@@ -21,7 +21,7 @@ abstract class _$ObjectWithEnumSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'color':
-        color = __value;
+        color = fromSerializedEnum(__value, Color, () => Color.values);
         return;
     }
     throwFieldNotFoundException(__key, 'ObjectWithEnum');

--- a/test/serializer/simple_test.g.dart
+++ b/test/serializer/simple_test.g.dart
@@ -83,10 +83,10 @@ abstract class _$NestedClassSerializable extends SerializableMap {
         name = __value;
         return;
       case 'list':
-        list = __value;
+        list = fromSerialized(__value, () => new List<dynamic>());
         return;
       case 'getter':
-        getter = __value;
+        getter = fromSerialized(__value, () => new TestGetter());
         return;
     }
     throwFieldNotFoundException(__key, 'NestedClass');
@@ -110,7 +110,7 @@ abstract class _$SetClassSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'names':
-        names = __value;
+        names = fromSerialized(__value, () => new Set<dynamic>());
         return;
     }
     throwFieldNotFoundException(__key, 'SetClass');
@@ -157,7 +157,7 @@ abstract class _$TestClass1Serializable extends SerializableMap {
         return intNumber;
       case 'ignored':
         return ignored;
-      case 'renamed':
+      case 'the_renamed':
         return renamed;
     }
     throwFieldNotFoundException(__key, 'TestClass1');
@@ -175,13 +175,13 @@ abstract class _$TestClass1Serializable extends SerializableMap {
         number = __value;
         return;
       case 'list':
-        list = __value;
+        list = fromSerialized(__value, () => new List<dynamic>());
         return;
       case 'myMap':
-        myMap = __value;
+        myMap = fromSerialized(__value, () => new Map<dynamic, dynamic>());
         return;
       case 'child':
-        child = __value;
+        child = fromSerialized(__value, () => new TestClass1());
         return;
       case 'intNumber':
         intNumber = __value;
@@ -189,7 +189,7 @@ abstract class _$TestClass1Serializable extends SerializableMap {
       case 'ignored':
         ignored = __value;
         return;
-      case 'renamed':
+      case 'the_renamed':
         renamed = __value;
         return;
     }
@@ -214,7 +214,7 @@ abstract class _$SimpleDateContainerSerializable extends SerializableMap {
   operator []=(Object __key, __value) {
     switch (__key) {
       case 'testDate':
-        testDate = __value;
+        testDate = fromSerializedDateTime(__value);
         return;
     }
     throwFieldNotFoundException(__key, 'SimpleDateContainer');
@@ -354,9 +354,9 @@ const $$TestClass1_fields_intNumber =
 const $$TestClass1_fields_ignored = const DeclarationMirror(
     name: 'ignored', type: bool, annotations: const [ignore]);
 const $$TestClass1_fields_renamed = const DeclarationMirror(
-    name: 'renamed',
-    type: String,
-    annotations: const [const SerializedName(r'the_renamed')]);
+  name: 'the_renamed',
+  type: String,
+);
 
 const TestClass1ClassMirror =
     const ClassMirror(name: 'TestClass1', constructors: const {
@@ -370,7 +370,7 @@ const TestClass1ClassMirror =
   'child': $$TestClass1_fields_child,
   'intNumber': $$TestClass1_fields_intNumber,
   'ignored': $$TestClass1_fields_ignored,
-  'renamed': $$TestClass1_fields_renamed
+  'the_renamed': $$TestClass1_fields_renamed
 }, getters: const [
   'name',
   'matter',
@@ -380,7 +380,7 @@ const TestClass1ClassMirror =
   'child',
   'intNumber',
   'ignored',
-  'renamed'
+  'the_renamed'
 ], setters: const [
   'name',
   'matter',
@@ -390,7 +390,7 @@ const TestClass1ClassMirror =
   'child',
   'intNumber',
   'ignored',
-  'renamed'
+  'the_renamed'
 ]);
 
 _SimpleDateContainer__Constructor([positionalParams, namedParams]) =>


### PR DESCRIPTION
- upgrade `serializable_core` to version `0.11.0` since
 this version now generates from methods which now allows
 convert objects from generic values.
- move `SerializedName` to `built_mirrors` library since
 the serialized name is now generated at build time